### PR TITLE
Update references to Creature to reference CreatureBoardAsset

### DIFF
--- a/TaleSpireChatServicePlugin/Patches/Patch.cs
+++ b/TaleSpireChatServicePlugin/Patches/Patch.cs
@@ -118,7 +118,7 @@ namespace LordAshes
             if (name.ToUpper() == "ANONYMOUS") { return ChatSource.anonymous; }
             foreach(CreatureBoardAsset asset in CreaturePresenter.AllCreatureAssets)
             {
-                if(asset.Creature.Name.StartsWith(name))
+                if(asset.Name.StartsWith(name))
                 {
                     return ChatSource.creature;
                 }

--- a/TaleSpireChatServicePlugin/Program.cs
+++ b/TaleSpireChatServicePlugin/Program.cs
@@ -27,6 +27,19 @@ namespace LordAshes
             anonymous = 999
         }
 
+        public class Talespire
+        {
+            public enum SourceRole
+            {
+                gm = 0,
+                player = 1,
+                creature = 2,
+                hideVolume = 3,
+                other = 888,
+                anonymous = 999
+            }
+        }
+
         public static Dictionary<string, Func<string, string, ChatSource, string>> handlers = new Dictionary<string, Func<string, string, ChatSource, string>>();
         
         private static Dictionary<string, Func<string, string, Talespire.SourceRole, string>> chatMessgeServiceHandlers = new Dictionary<string, Func<string, string, Talespire.SourceRole, string>>();
@@ -57,8 +70,8 @@ namespace LordAshes
                         CreaturePresenter.TryGetAsset(LocalClient.SelectedCreatureId, out asset);
                         if (asset != null)
                         {
-                            Debug.Log("Chat Service Plugin: Deselecting '" + asset.Creature.Name.Substring(0, asset.Creature.Name.IndexOf("<")) + "' (" + asset.Creature.CreatureId + ").");
-                            asset.Creature.Deselect();
+                            Debug.Log("Chat Service Plugin: Deselecting '" + asset.Name.Substring(0, asset.Name.IndexOf("<")) + "' (" + asset.CreatureId + ").");
+                            asset.Deselect();
                             LocalClient.SelectedCreatureId = CreatureGuid.Empty;
                             ChatInputBoardTool __instance = GameObject.FindObjectOfType<ChatInputBoardTool>();
                             PatchAssistant.SetField(__instance, "_selectedCreature", null);

--- a/TaleSpireChatServicePlugin/Program.cs
+++ b/TaleSpireChatServicePlugin/Program.cs
@@ -27,19 +27,6 @@ namespace LordAshes
             anonymous = 999
         }
 
-        public class Talespire
-        {
-            public enum SourceRole
-            {
-                gm = 0,
-                player = 1,
-                creature = 2,
-                hideVolume = 3,
-                other = 888,
-                anonymous = 999
-            }
-        }
-
         public static Dictionary<string, Func<string, string, ChatSource, string>> handlers = new Dictionary<string, Func<string, string, ChatSource, string>>();
         
         private static Dictionary<string, Func<string, string, Talespire.SourceRole, string>> chatMessgeServiceHandlers = new Dictionary<string, Func<string, string, Talespire.SourceRole, string>>();


### PR DESCRIPTION
Creature's properties/methods have been squashed down onto CreatureBoardAsset, fixes issues encountered in the 5e plugin with same fix.